### PR TITLE
fix: disposeAll() ConcurrentModificationError on non-web platforms

### DIFF
--- a/lib/custom_mouse_cursor.dart
+++ b/lib/custom_mouse_cursor.dart
@@ -1388,14 +1388,19 @@ class CustomMouseCursor extends MouseCursor {
     if (_Logger.logging) {
       _Logger.log('disposeAll() called');
     }
-    for (final cursor in _cursorCacheOfAllCreatedCursors.values) {
+    // Take a snapshot before iterating — dispose() calls remove() on the same
+    // map, so iterating .values directly throws ConcurrentModificationError.
+    final all = _cursorCacheOfAllCreatedCursors.values.toList();
+    _cursorCacheOfAllCreatedCursors.clear();
+    for (final cursor in all) {
       if (_Logger.logging) {
         _Logger.log(
             'Calling dispose on ${_debugPrintPossibleCSSDataUriString(cursor.key)}');
       }
-      cursor.dispose();
+      if (!kIsWeb) {
+        _CustomMouseCursorPlatformInterface.deleteCursor(cursor.key);
+      }
     }
-    _cursorCacheOfAllCreatedCursors.clear();
   }
 
   static ImageConfiguration? _lastImageConfiguration;


### PR DESCRIPTION
## Problem

`disposeAll()` iterates over `_cursorCacheOfAllCreatedCursors.values` and calls `cursor.dispose()` on each entry. However, `dispose()` internally calls `_cursorCacheOfAllCreatedCursors.remove(key)`, which modifies the map during iteration.

This causes a `ConcurrentModificationError` **every time** `disposeAll()` is called on non-web platforms (macOS, Windows, Linux). It is not a race condition — it is a deterministic bug.

## Fix

1. Snapshot `.values.toList()` before iterating
2. Clear the map first
3. Delete native platform cursors directly via `_CustomMouseCursorPlatformInterface.deleteCursor()` instead of calling `dispose()` (which would try to `remove()` from an already-cleared map)

## Reproduction

Any non-web Flutter app that calls `CustomMouseCursor.disposeAll()` will crash with:
```
Concurrent modification during iteration: Instance of '_HashMap'.
```